### PR TITLE
README: format with mdsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ nix run github:numtide/nixos-anywhere -- root@yourip --flake github:your-user/yo
 The parameter passed to `--flake` should point to your nixos configuration
 exposed in your flake (`nixosConfigurations.your-system` in the example above).
 
-`nixos-anywhere --help`
-
-```shell
+<!-- `$ ./src/nixos-anywhere.sh --help` -->
+```
 Usage: nixos-anywhere [options] ssh-host
 
 Options:

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
       perSystem = { config, ... }: {
         treefmt = {
           projectRootFile = "flake.nix";
+          programs.mdsh.enable = true;
           programs.nixpkgs-fmt.enable = true;
           programs.shellcheck.enable = true;
           programs.shfmt.enable = true;


### PR DESCRIPTION
Use mdsh to keep the option parsing outputs in the README in sync with the script.