### PR TITLE
src/nixos-anywhere.sh: add shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ nix run github:numtide/nixos-anywhere -- root@yourip --flake github:your-user/yo
 The parameter passed to `--flake` should point to your nixos configuration
 exposed in your flake (`nixosConfigurations.your-system` in the example above).
 
-<!-- `$ ./src/nixos-anywhere.sh --help` -->
+<!-- `$ bash ./src/nixos-anywhere.sh --help` -->
 ```
 Usage: nixos-anywhere [options] ssh-host
 

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 showUsage() {
   cat <<USAGE
 Usage: nixos-anywhere [options] ssh-host


### PR DESCRIPTION
It's not strictly needed because Nix wraps it with writeShellApplication, but it makes it easier for the script to be standalone and use the right syntax highlighter in shells.