### PR TITLE
add -i to allow passing private key files

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,8 +19,10 @@ Usage: nixos-anywhere [options] ssh-host
 
 Options:
 
-* -f, --flake flake
-  set the flake to install the system from
+* -f, --flake <flake_uri>
+  set the flake to install the system from.
+* -i <identity_file>
+  selects which SSH private key file to use.
 * -L, --print-build-logs
   print full build logs
 * -s, --store-paths

--- a/tests/from-nixos-with-sudo.nix
+++ b/tests/from-nixos-with-sudo.nix
@@ -20,6 +20,7 @@
     installer.succeed("echo super-secret > /tmp/disk-1.key")
     output = installer.succeed("""
       nixos-anywhere \
+        -i /root/.ssh/install_key \
         --debug \
         --kexec /etc/nixos-anywhere/kexec-installer \
         --stop-after-disko \
@@ -27,9 +28,9 @@
         --disk-encryption-keys /tmp/disk-2.key <(echo another-secret) \
         --store-paths /etc/nixos-anywhere/disko /etc/nixos-anywhere/system-to-install \
         nixos@installed >&2
-      echo "disk-1.key: '$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+      echo "disk-1.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
         root@installed cat /tmp/disk-1.key)'"
-      echo "disk-2.key: '$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+      echo "disk-2.key: '$(ssh -i /root/.ssh/install_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
         root@installed cat /tmp/disk-2.key)'"
     """)
 

--- a/tests/from-nixos.nix
+++ b/tests/from-nixos.nix
@@ -24,6 +24,7 @@
     installer.succeed("echo value > /tmp/extra-files/var/lib/secrets/key")
     installer.succeed("""
       nixos-anywhere \
+        -i /root/.ssh/install_key \
         --debug \
         --kexec /etc/nixos-anywhere/kexec-installer \
         --extra-files /tmp/extra-files \

--- a/tests/modules/installer.nix
+++ b/tests/modules/installer.nix
@@ -9,7 +9,7 @@ let
 in
 {
   system.activationScripts.rsa-key = ''
-    ${pkgs.coreutils}/bin/install -D -m600 ${./ssh-keys/ssh} /root/.ssh/id_rsa
+    ${pkgs.coreutils}/bin/install -D -m600 ${./ssh-keys/ssh} /root/.ssh/install_key
   '';
 
   environment.systemPackages = [ inputs.nixos-anywhere ];


### PR DESCRIPTION
Mirror the `-i` option from SSH, so you can run `nixos-anywhere ~/.ssh/other_key`.

This commit also fixes an issue where the generated key-pair would stay
around when using the SSH_PRIVATE_KEY env var.
