### PR TITLE
Don't claim Linux requirement on source machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ data has been migrated.
 ## Prerequisites
 
 - Source Machine:
+
   - Can be any machine with Nix installed, e.g. a NixOS machine.
-  - Should be able to build nix derivations for the target platform. Otherwise 
+  - Should be able to build nix derivations for the target platform. Otherwise
     `--build-on-remote` can be used.
 
 - Target Machine:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ data has been migrated.
 ## Prerequisites
 
 - Source Machine:
-
-  - Can be any Linux machine with Nix installed, or a NixOS machine.
+  - Can be any machine with Nix installed, e.g. a NixOS machine.
+  - Should be able to build nix derivations for the target platform. Otherwise 
+    `--build-on-remote` can be used.
 
 - Target Machine:
 


### PR DESCRIPTION
As nixos-anywhere is a simple bash script, I'd expect it to run at least pretty much anywhere where nix, bash and curl are supported?

A user mentioned being confused about whether it would be supported to run nixos-anywhere *from* a macOS machine and I believe it should, but personally lack a machine to test it myself.