### PR TITLE
terraform: do not show private key in local-exec logs

### DIFF
--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -11,5 +11,6 @@ resource "null_resource" "nixos-remote" {
       SSH_PRIVATE_KEY = var.ssh_private_key
     }
     command = "nix run --extra-experimental-features 'nix-command flakes' path:${path.module}/../..#nixos-anywhere -- ${local.nixos_anywhere_flags}"
+    quiet   = var.debug_logging
   }
 }

--- a/terraform/nixos-rebuild/deploy.sh
+++ b/terraform/nixos-rebuild/deploy.sh
@@ -23,6 +23,7 @@ sshOpts=(-p "${TARGET_PORT}")
 sshOpts+=(-o UserKnownHostsFile=/dev/null)
 sshOpts+=(-o StrictHostKeyChecking=no)
 
+set +x
 if [[ -n ${SSH_KEY+x} && ${SSH_KEY} != "-" ]]; then
   sshPrivateKeyFile="$workDir/ssh_key"
   # Create the file with 0700 - umask calculation: 777 - 700 = 077
@@ -33,6 +34,7 @@ if [[ -n ${SSH_KEY+x} && ${SSH_KEY} != "-" ]]; then
   unset SSH_AUTH_SOCK # don't use system agent if key was supplied
   sshOpts+=(-o "IdentityFile=${sshPrivateKeyFile}")
 fi
+set -x
 
 try=1
 until NIX_SSHOPTS="${sshOpts[*]}" nix copy -s --experimental-features nix-command --to "ssh://$TARGET" "$NIXOS_SYSTEM"; do


### PR DESCRIPTION
While running terraform with and without verbose mode enabled, we don't want the private key content to be shown in the terraform apply output.