### PR TITLE
Create ~/.ssh folder and add .direnv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+/.direnv

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -179,6 +179,8 @@ fi
 ssh_key_dir=$(mktemp -d)
 trap 'rm -rf "$ssh_key_dir"' EXIT
 mkdir -p "$ssh_key_dir"
+# ssh-copy-id requires this directory
+mkdir -p "$HOME/.ssh/"
 ssh-keygen -t ed25519 -f "$ssh_key_dir"/nixos-anywhere -P "" -C "nixos-anywhere" >/dev/null
 
 # parse flake nixos-install style syntax, get the system attr


### PR DESCRIPTION
Heya

I tried to run `nixos-anywhere` inside of a `nixpkgs/nix:latest` docker container (because I'd like to be able to use it on a system without nix installed locally).
Ran into the following infinite loop:
```bash
### Uploading install SSH keys ###                                           
/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/tmp/tmp.ebg98xQ7IX/nixos-anywhere.pub"
mktemp: failed to create directory via template '/root/.ssh/ssh-copy-id.XXXXXXXXXX': No such file or directory
/usr/bin/ssh-copy-id: ERROR: failed to create required temporary directory under ~/.ssh
/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/tmp/tmp.ebg98xQ7IX/nixos-anywhere.pub"
mktemp: failed to create directory via template '/root/.ssh/ssh-copy-id.XXXXXXXXXX': No such file or directory
/usr/bin/ssh-copy-id: ERROR: failed to create required temporary directory under ~/.ssh
```

After manually creating the ~/.ssh (or in that regard `/root/.ssh` folder it asked me for the password.

And those tests... I really need to take a deeper look into nix testing at some point. they look polished! (And take ages 😄 )
Ran all tests successful. :)