### PR TITLE
Bugfix: Handle parsing ssh hostname on MacOS

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -222,7 +222,7 @@ if [[ -n ${ssh_private_key_file-} ]]; then
 fi
 
 ssh_settings=$(ssh -G "${ssh_connection}")
-ssh_host=$(echo "$ssh_settings" | awk '/^host / { print $2 }')
+ssh_host=$(echo "$ssh_settings" | awk '/^host(name?) / { print $2 }')
 ssh_port=$(echo "$ssh_settings" | awk '/^port / { print $2 }')
 
 step Uploading install SSH keys


### PR DESCRIPTION
Ran `nix run github:numtide/nixos-anywhere -- -f ".#$host"  --debug --build-on-remote` on MacOS and got `pubkey='ERROR: failed to retrieve host public key for root@$IP'`.

Looks like the issue is that `ssh -G` on MacOS returns `hostname` instead of `host`. This is causing `ssh_host` to be empty.

