### PR TITLE
Amended README and Quickstart 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ data has been migrated.
 ## Prerequisites
 
 - Source Machine:
-
+  
   - Can be any machine with Nix installed, e.g. a NixOS machine.
   - Should be able to build nix derivations for the target platform. Otherwise
     `--build-on-remote` can be used.
 
 - Target Machine:
-
+  
   - Unless you're using the option to boot from a NixOS installer image, or
     providing your own `kexec` image, it must be running x86-64 Linux with kexec
     support. Most `x86_64` Linux systems do have kexec support. By providing
@@ -198,6 +198,14 @@ nix run github:numtide/nixos-anywhere -- --flake .#hetzner-cloud root@135.181.25
 Note that this command references the URL of your flake, in this case `.#`,
 together with the name of the system `hetzner-cloud`, as highlighted by the
 comment in the sample flake.
+
+This will configure and build the new NixOS server. Since the configurations are defined in the flake, it will not create `/etc/nixos/configuration.nix`. If you need to make changes to the configuration in future, you should make the changes in the flake, and rebuild using the --flake option as shown below:
+
+
+
+```
+nixos-rebuild --flake <flake URL> switch
+```
 
 The [Quickstart Guide](./docs/quickstart.md) gives more information on how to
 run **nixos-anywhere** in its simplest form. For more specific instructions to

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -158,7 +158,6 @@ nix flake update
 
 The new server's configurations are defined in the flake. `nixos-anywhere` does not create `etc/nixos/configuration.nix`since it expects the server to be administered remotely. Any future changes to the configuration should be made to the flake, and you would reference this flake when doing the rebuild:
 
-NoneBashCSSCC#ElixirErlangGoGraphQLGroovyHaskellHCLHTMLINIJavaJavaScriptJSONJSXKotlinLispLuaMermaid DiagramNixObjective-COCamlPerlPHPPowershellPythonRubyRustScalaSQLSoliditySwiftTOMLTSXTypeScriptVisual BasicYAMLZigCopy
 
 ```
 nixos-rebuild --flake <URL to your flake> switch

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,8 +17,7 @@ in the [How To Guide](./howtos.md) as and when they are available.
 
 You will need:
 
-- A [flake](https://nixos.wiki/wiki/Flakes) that controls the actions to be
-  performed
+- A [flake](https://nixos.wiki/wiki/Flakes) that controls the actions to be performed and contains or imports the configuration of the new server
 - A disk configuration containing details of the file system that will be
   created on the new server.
 
@@ -43,8 +42,7 @@ nix flake init
 
 This will create a flake in a file named flake.nix. Edit the flake to suit your
 requirements. For a minimal installation, you can paste in the contents of the
-example flake from
-[here](https://github.com/numtide/nixos-anywhere-examples/blob/main/flake.nix).
+example flake from [here](https://github.com/numtide/nixos-anywhere-examples/blob/main/flake.nix). 
 
 Lines 29 in the sample file reads:
 
@@ -85,15 +83,15 @@ example uses a local directory on the source machine.
 
 6. You can now run **nixos-anywhere** from the command line as shown below,
    where:
-
+   
    - `<path to configuration>` is the path to the directory or repository
      containing `flake.nix` and `disk-config.nix`
-
+   
    - `<configuration name>` must match the name that immediately follows the
      text `nixosConfigurations.` in the flake, as indicated by the comment in
      the
      [example](https://github.com/numtide/nixos-anywhere-examples/blob/main/flake.nix)).
-
+   
    - `<ip address>` is the IP address of the target machine.
 
 ```
@@ -156,6 +154,14 @@ directory containing the flake to update `flake.lock` before rerunning
 
 ```
 nix flake update
+```
+
+The new server's configurations are defined in the flake. `nixos-anywhere` does not create `etc/nixos/configuration.nix`since it expects the server to be administered remotely. Any future changes to the configuration should be made to the flake, and you would reference this flake when doing the rebuild:
+
+NoneBashCSSCC#ElixirErlangGoGraphQLGroovyHaskellHCLHTMLINIJavaJavaScriptJSONJSXKotlinLispLuaMermaid DiagramNixObjective-COCamlPerlPHPPowershellPythonRubyRustScalaSQLSoliditySwiftTOMLTSXTypeScriptVisual BasicYAMLZigCopy
+
+```
+nixos-rebuild --flake <URL to your flake> switch
 ```
 
 For more information on different use cases of **nixos-anywhere** please refer


### PR DESCRIPTION
Include the fact that future configurations to the new server will be controlled by the flake, not /etc/nixos/configuration.nix