### PR TITLE
Pass ssh_args to nix copy and nix build SSH invocations

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -189,13 +189,13 @@ ssh_() {
 }
 
 nix_copy() {
-  NIX_SSHOPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $ssh_key_dir/nixos-anywhere" nix copy \
+  NIX_SSHOPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $ssh_key_dir/nixos-anywhere ${ssh_args[*]}" nix copy \
     "${nix_options[@]}" \
     "${nix_copy_options[@]}" \
     "$@"
 }
 nix_build() {
-  NIX_SSHOPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $ssh_key_dir/nixos-anywhere" nix build \
+  NIX_SSHOPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $ssh_key_dir/nixos-anywhere ${ssh_args[*]}" nix build \
     --print-out-paths \
     --no-link \
     "${nix_options[@]}" \


### PR DESCRIPTION
This is necessary for --post-kexec-ssh-port to be useful in situations involving port forwarding, such as when running on qemu
