### PR TITLE
Don't add trailing newline to keyfile

### DIFF
--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -181,7 +181,7 @@ echo "my-super-safe-password" > /tmp/disk-1.key
 # Call nixos-anywhere with disk encryption keys
 nixos-anywhere \
   --disk-encryption-keys /tmp/disk-1.key /tmp/disk-1.key \
-  --disk-encryption-keys /tmp/disk-2.key <(pass my-disk-encryption-password) \
+  --disk-encryption-keys /tmp/disk-2.key <(echo -n $(pass my-disk-encryption-password)) \
   --flake '.#your-host' \
   root@yourip
 ```


### PR DESCRIPTION
`pass` will add an trailing newline which renders luks login via prompt useless