### PR TITLE
force use of bash to allow for non-posix user shells

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -283,7 +283,7 @@ done
 import_facts() {
   local facts filtered_facts
   if ! facts=$(
-    ssh_ -o ConnectTimeout=10 -- <<SSH
+    ssh_ -o ConnectTimeout=10 bash -- <<SSH
 set -efu ${enable_debug}
 has(){
   command -v "\$1" >/dev/null && echo "y" || echo "n"
@@ -347,7 +347,7 @@ if [[ ${is_kexec-n} == "n" ]] && [[ ${is_installer-n} == "n" ]]; then
   fi
 
   step Switching system into kexec
-  ssh_ <<SSH
+  ssh_ bash <<SSH
 set -efu ${enable_debug}
 $maybe_sudo rm -rf /root/kexec
 $maybe_sudo mkdir -p /root/kexec
@@ -436,7 +436,7 @@ if [[ -n ${extra_files-} ]]; then
 fi
 
 step Installing NixOS
-ssh_ <<SSH
+ssh_ bash <<SSH
 set -efu ${enable_debug}
 # when running not in nixos we might miss this directory, but it's needed in the nixos chroot during installation
 export PATH=\$PATH:/run/current-system/sw/bin 


### PR DESCRIPTION
I use fish, but the current command will likely fail with nushell and others. Make the bash call explicit to avoid failures such as:

```
fish: Unsupported use of '='. In fish, please use 'set is_nixos $(if test -f /etc/os-release && grep -q ID=nixos /etc/os-release; then echo "y"; else echo "n"; fi)'.
```

Ideally this would be handled in `_ssh`, but there are some sporadic args for ssh in some of the calls. A quick perusal looked like they were just connection timeout options, which I'm wondering if we can move into `_ssh`. If this was done, then all calls could pass through bash. For now I've targeted the steps that require posix/bashisms.