### PR TITLE
docs: add meta description to package

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -36,7 +36,7 @@ in
   '';
   inherit runtimeInputs;
 }) // {
-  meta = {inherit (import ../flake.nix) description;};
+  meta = { inherit (import ../flake.nix) description; };
   # Dependencies for our devshell
   devShell = mkShellNoCC {
     packages = runtimeInputs ++ [ openssh ];

--- a/src/default.nix
+++ b/src/default.nix
@@ -35,6 +35,7 @@ in
     ${builtins.readFile ./nixos-anywhere.sh}
   '';
   inherit runtimeInputs;
+  meta = {inherit (import ../flake.nix) description;};
 }) // {
   # Dependencies for our devshell
   devShell = mkShellNoCC {

--- a/src/default.nix
+++ b/src/default.nix
@@ -35,8 +35,8 @@ in
     ${builtins.readFile ./nixos-anywhere.sh}
   '';
   inherit runtimeInputs;
-  meta = {inherit (import ../flake.nix) description;};
 }) // {
+  meta = {inherit (import ../flake.nix) description;};
   # Dependencies for our devshell
   devShell = mkShellNoCC {
     packages = runtimeInputs ++ [ openssh ];


### PR DESCRIPTION
# Context

`numtide/devshell`, amonge others takes an optional contract on a derivations `meta.description` to the effect that it's non existence in `nixos-anywere` results in degraded UX when used with `devshell`:

```console
[bootstrap]

  nixos-anywhere
  nixos-generate - Collection of image builders
  writedisk      - Small utility for writing a disk image to a USB drive
```

# Proposed Solution

Add `meta.description` to the following effect (tested):

```console
[bootstrap]

  nixos-anywhere - A universal nixos installer, just needs ssh access to the target system
  nixos-generate - Collection of image builders
  writedisk      - Small utility for writing a disk image to a USB drive
```
