### PR TITLE
Remove dependency on openssh >= 9.2

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -839,7 +839,7 @@ main() {
 
   sshSettings=$(ssh "${sshArgs[@]}" -G "${sshConnection}")
   sshUser=$(echo "$sshSettings" | awk '/^user / { print $2 }')
-  sshHost=$(echo "$sshSettings" | awk '/^host / { print $2 }')
+  sshHost="${sshConnection//*@/}"
 
   uploadSshKey
 


### PR DESCRIPTION
#562 Introduced a dependency on openssh >= 9.2 as discovered in #567 

Instead of relying `ssh -G` to give the hostname field, we can just compute it instead.