### PR TITLE
nixos-anywhere: Install jq when using --no-disko-deps

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -719,7 +719,11 @@ runDisko() {
   fi
 
   step Formatting hard drive with disko
-  runSsh "$diskoScript"
+  local installDeps=""
+  if [[ ${diskoDeps} == "n" ]]; then
+    installDeps="nix --extra-experimental-features 'nix-command flakes' profile install nixpkgs#jq &&"
+  fi
+  runSsh "$installDeps$diskoScript"
 }
 
 nixosInstall() {


### PR DESCRIPTION
This is a different way of fixing https://github.com/nix-community/disko/pull/1091

Nixos-anywhere will run commands like:

```
jq -r -f /nix/store/fpwn44vygjj6bfn8s1jj9p8yh6jhfxni-disk-deactivate/zfs-swap-deactivate.jq
...
jq -r --arg disk_to_clear /dev/sda -f /nix/store/fpwn44vygjj6bfn8s1jj9p8yh6jhfxni-disk-deactivate/disk-deactivate.jq
```
During installation, and with --no-disko-deps, `jq` isn't available on the official nixos-installer, and these command can fail.