### PR TITLE
Check for setsid respecting --wait

### DIFF
--- a/src/get-facts.sh
+++ b/src/get-facts.sh
@@ -18,6 +18,6 @@ hasSudo=$(has sudo)
 hasDoas=$(has doas)
 hasWget=$(has wget)
 hasCurl=$(has curl)
-hasSetsid=$(has setsid)
+hasSetsid=$(if [ "$(has setsid)" = "y" ] && setsid --wait true 2>/dev/null; then echo "y"; else echo "n"; fi)
 hasNixOSFacter=$(command -v nixos-facter >/dev/null && echo "y" || echo "n")
 FACTS

--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -993,7 +993,7 @@ main() {
   fi
 
   if [[ ${hasSetsid-n} == "n" ]]; then
-    abort "no setsid command found, but required to run the kexec script under a new session"
+    abort "no setsid command respecting --wait found, but required to run the kexec script under a new session"
   fi
 
   if [[ ${isOs} != "Linux" ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved detection of setsid support to only enable it when available and functional with --wait, reducing false positives.
  - Suppressed unnecessary error output during detection to keep logs clean.
  - Clarified the failure message to state that a setsid command supporting --wait is required, providing clearer guidance when unavailable.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->