### PR TITLE
nixos-anywhere: ensure Nix options are passed when getting substituters

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -1038,8 +1038,8 @@ main() {
 
   # Get substituters from the machine and add them to the installer
   if [[ ${machineSubstituters} == "y" && -n ${flake} ]]; then
-    substituters=$(nix --extra-experimental-features 'nix-command flakes' eval --apply toString "${flake}"#"${flakeAttr}".nix.settings.substituters)
-    trustedPublicKeys=$(nix --extra-experimental-features 'nix-command flakes' eval --apply toString "${flake}"#"${flakeAttr}".nix.settings.trusted-public-keys)
+    substituters=$(nix eval "${nixOptions[@]}" --apply toString "${flake}"#"${flakeAttr}".nix.settings.substituters)
+    trustedPublicKeys=$(nix eval "${nixOptions[@]}" --apply toString "${flake}"#"${flakeAttr}".nix.settings.trusted-public-keys)
 
     runSsh sh <<SSH || true
 mkdir -p ~/.config/nix


### PR DESCRIPTION
This is necessary for a test in Clan which passes `--option store`, otherwise these `nix eval` commands would fail by trying to use the wrong Nix Store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced deprecated Nix invocations to eliminate warnings and improve compatibility with newer environments. Behavior remains the same, including how configuration is extracted and applied.
* **Chores**
  * Streamlined command execution by centralizing option handling, resulting in cleaner, more consistent script behavior without changing user-facing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->