### PR TITLE
Fix: Update sshStoreSettings variable to append key-value pairs correctly

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -283,7 +283,7 @@ parseArgs() {
       shift
       value=$2
       shift
-      sshStoreSettings+="$sshStoreSettings$key=$value&"
+      sshStoreSettings+="&$key=$value"
       shift
       ;;
     --post-kexec-ssh-port)


### PR DESCRIPTION
Following shows how ssh store URL looks before and after fix when flag `--ssh-store-setting foo bar` was used.

before:
```
ssh://root@localhost?compress=truecompress=truefoo=bar&
```

after
```
ssh://root@localhost?compress=true&foo=bar
```