### PR TITLE
nixos-anywhere: Fix parsing of `--ssh-store-setting` without skipping next arg

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -280,10 +280,10 @@ parseArgs() {
       ;;
     --ssh-store-setting)
       key=$2
-      shift
-      value=$2
-      shift
+      value=$3
       sshStoreSettings+="&$key=$value"
+      shift
+      shift
       ;;
     --post-kexec-ssh-port)
       postKexecSshPort=$2


### PR DESCRIPTION
Fix parsing of the `--ssh-store-setting` without skipping the next
argument.

There was an extra shift in the `--ssh-store-setting`, also adjusted the
shifts to be in line with the others.

Credit to @name-snrl for the report, thank you.
