### PR TITLE
Fix: remove extra shift in --ssh-store-setting argument parsing

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -284,7 +284,6 @@ parseArgs() {
       value=$2
       shift
       sshStoreSettings+="&$key=$value"
-      shift
       ;;
     --post-kexec-ssh-port)
       postKexecSshPort=$2


### PR DESCRIPTION

The --ssh-store-setting option takes two arguments (key and value).
The outer while loop already shifts past $1 (the option flag), so
only two shifts are needed inside the case block for the two arguments.

The third shift was causing the parser to skip the next argument,
breaking argument parsing when --ssh-store-setting was used.

Reported-by: name-snrl
Fixes: bad98b0685cf ("Add '--ssh-store-setting' option")


