### PR TITLE
Terraform: null_resource definition is not compatible with recent versions

### DIFF
--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -31,6 +31,5 @@ resource "null_resource" "nixos-remote" {
       ARGUMENTS = local.arguments
     }, var.extra_environment)
     command = "${path.module}/run-nixos-anywhere.sh ${join(" ", local.disk_encryption_key_scripts)}"
-    quiet   = var.debug_logging
   }
 }


### PR DESCRIPTION
With current versions of null_provider, you run into:

```
│ Error: Unsupported argument
│
│   on .terraform/modules/deploy/terraform/install/main.tf line 34, in resource "null_resource" "nixos-remote":
│   34:     quiet   = var.debug_logging
│
│ An argument named "quiet" is not expected here.
```


The main issue is that the "quiet" argument has been removed. 