### PR TITLE
feat(nixos-install TF module): Add non sensite option

### DIFF
--- a/terraform/install/main.tf
+++ b/terraform/install/main.tf
@@ -28,7 +28,7 @@ resource "null_resource" "nixos-remote" {
   }
   provisioner "local-exec" {
     environment = merge({
-      ARGUMENTS = local.arguments
+      ARGUMENTS = var.suppress_sensitive ? local.arguments : nonsensitive(local.arguments)
     }, var.extra_environment)
     command = "${path.module}/run-nixos-anywhere.sh ${join(" ", local.disk_encryption_key_scripts)}"
   }

--- a/terraform/install/variables.tf
+++ b/terraform/install/variables.tf
@@ -127,3 +127,9 @@ variable "copy_host_keys" {
   description = "copy over existing /etc/ssh/ssh_host_* host keys to the installation"
   default     = false
 }
+
+variable "suppress_sensitive" {
+  type        = bool
+  description = "Suppress sensitive values in output."
+  default     = true
+}


### PR DESCRIPTION
Make it possible to print out nixos istall output despite of containing sensitive values.