### PR TITLE
Fix SSH argument handling for timeouts and complex options

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -481,13 +481,13 @@ runSsh() {
 }
 
 nixCopy() {
-  NIX_SSHOPTS="${sshArgs[*]}" nix copy \
+  NIX_SSHOPTS="$(printf '%q ' "${sshArgs[@]}")" nix copy \
     "${nixOptions[@]}" \
     "${nixCopyOptions[@]}" \
     "$@"
 }
 nixBuild() {
-  NIX_SSHOPTS="${sshArgs[*]}" nix build \
+  NIX_SSHOPTS="$(printf '%q ' "${sshArgs[@]}")" nix build \
     --print-out-paths \
     --no-link \
     "${nixBuildFlags[@]}" \
@@ -567,7 +567,11 @@ uploadSshKey() {
 importFacts() {
   step Gathering machine facts
   local facts filteredFacts
-  if ! facts=$(runSsh -o ConnectTimeout=10 enableDebug=$enableDebug sh -- <"$here"/get-facts.sh); then
+  # shellcheck disable=SC2030,SC2031
+  if ! facts=$(
+    sshArgs+=("-o" "ConnectTimeout=10")
+    runSsh enableDebug=$enableDebug sh -- <"$here"/get-facts.sh
+  ); then
     exit 1
   fi
   filteredFacts=$(echo "$facts" | grep -E '^(has|is|remote)[A-Za-z0-9_]+=\S+')
@@ -662,16 +666,28 @@ generateHardwareConfig() {
       # `--extra-experimental-features "nix-command flakes"`.
       # We can use the following Bash-ism described at: https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion-1
       # For more information: https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script
-      runSshNoTty -o ConnectTimeout=10 \
-        nix shell "${nixOptions[@]@Q}" nixpkgs#nixos-facter -c ${maybeSudo} nixos-facter >"$hardwareConfigPath"
+      # shellcheck disable=SC2030,SC2031
+      (
+        sshArgs+=("-o" "ConnectTimeout=10")
+        runSshNoTty \
+          nix shell "${nixOptions[@]@Q}" nixpkgs#nixos-facter -c ${maybeSudo} nixos-facter
+      ) >"$hardwareConfigPath"
     else
       step "Generating facter.json using nixos-facter"
-      runSshNoTty -o ConnectTimeout=10 ${maybeSudo} nixos-facter >"$hardwareConfigPath"
+      # shellcheck disable=SC2030,SC2031
+      (
+        sshArgs+=("-o" "ConnectTimeout=10")
+        runSshNoTty ${maybeSudo} nixos-facter
+      ) >"$hardwareConfigPath"
     fi
     ;;
   nixos-generate-config)
     step "Generating hardware-configuration.nix using nixos-generate-config"
-    runSshNoTty -o ConnectTimeout=10 nixos-generate-config --show-hardware-config --no-filesystems >"$hardwareConfigPath"
+    # shellcheck disable=SC2030,SC2031
+    (
+      sshArgs+=("-o" "ConnectTimeout=10")
+      runSshNoTty nixos-generate-config --show-hardware-config --no-filesystems
+    ) >"$hardwareConfigPath"
     ;;
   *)
     abort "Unknown hardware config backend: $hardwareConfigBackend"
@@ -810,6 +826,7 @@ EOF
 
   # use the default SSH port to connect at this point
   local i
+  # shellcheck disable=SC2031
   for i in "${!sshArgs[@]}"; do
     if [[ ${sshArgs[i]} == "-p" ]]; then
       sshArgs[i + 1]=$postKexecSshPort
@@ -824,7 +841,11 @@ EOF
   sshConnection="root@${sshHost}"
 
   # waiting for machine to become available again
-  until runSsh -o ConnectTimeout=10 -- exit 0; do sleep 5; done
+  # shellcheck disable=SC2030,SC2031
+  until (
+    sshArgs+=("-o" "ConnectTimeout=10")
+    runSsh -- exit 0
+  ); do sleep 5; done
 
   importFacts
 
@@ -968,7 +989,7 @@ main() {
       printf '%s\n' "$SSH_PRIVATE_KEY" >"$sshPrivateKeyFile"
     )
   fi
-
+  # shellcheck disable=SC2031
   sshSettings=$(ssh "${sshArgs[@]}" -G "${sshConnection}")
   sshUser=$(echo "$sshSettings" | awk '/^user / { print $2 }')
   sshHost="${sshConnection//*@/}"
@@ -1010,7 +1031,11 @@ main() {
   # Before we do not have a valid hardware configuration we don't know the machine system
   if [[ ${buildOn} == "auto" ]]; then
     local remoteSystem
-    remoteSystem=$(runSshNoTty -o ConnectTimeout=10 nix --extra-experimental-features nix-command config show system)
+    # shellcheck disable=SC2030,SC2031
+    remoteSystem=$(
+      sshArgs+=("-o" "ConnectTimeout=10")
+      runSshNoTty nix --extra-experimental-features nix-command config show system
+    )
     checkBuildLocally "${remoteSystem}"
     # if we cannot figure it out at this point, we will build on the remote host
     if [[ ${buildOn} == "auto" ]]; then


### PR DESCRIPTION
This PR fixes two related issues with how SSH arguments are propagated, which were causing failures for deployments using complex SSH options (e.g., `ProxyCommand` with arguments) or relying on `ConnectTimeout`.

### Issues Fixed

**1. Fix `NIX_SSHOPTS` Quoting**
`sshArgs` was being flattened into `NIX_SSHOPTS` using `"${sshArgs[*]}"`. This naive expansion destroys the quoting of array elements that contain spaces.

Passing `--ssh-option "ProxyCommand='wrapper.sh' %h %p"` would result in `nix` splitting the proxy command string, causing SSH to execute the wrapper without arguments (failed IAP tunnels, etc.).

**Fix:** Changed to `NIX_SSHOPTS="$(printf '%q ' "${sshArgs[@]}")"` to properly shell-escape the arguments, preserving the structure of complex flags when passed to `nix`.

**2. Fix `ConnectTimeout` Injection**
Internal calls like `runSsh -o ConnectTimeout=10` were broken because `runSsh` appends positional arguments (`$@`) *after* the destination.

`ssh root@host -o ConnectTimeout=10` tries to execute `-o` as a **remote command** on the server. This returns exit code 127 (command not found) instead of actually setting a connection timeout, breaking logic that relies on exit codes (like the post-kexec wait loop).

**Fix:** Refactored these calls to append `-o ConnectTimeout=10` to the `sshArgs` array (scoped within subshells where appropriate) so they are correctly passed as SSH flags *before* the destination.
