### PR TITLE
chore(nix/flake): Update `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,15 +48,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1769079217,
-        "narHash": "sha256-R6qzhu+YJolxE2vUsPQWWwUKMbAG5nXX3pBtg8BNX38=",
-        "owner": "Enzime",
+        "lastModified": 1776950483,
+        "narHash": "sha256-ciWvxGmVY4axQSVpUpCUFM1ejHb1LyZ54TrTPeDL3aU=",
+        "owner": "a-kenji",
         "repo": "nix-vm-test",
-        "rev": "58c15f78947b431d6c206e0966500c7e9139bd2f",
+        "rev": "f02b5e1bb5bcb0dbdb60e402fa567f1ceab1af11",
         "type": "github"
       },
       "original": {
-        "owner": "Enzime",
+        "owner": "a-kenji",
         "ref": "pr-105-latest",
         "repo": "nix-vm-test",
         "type": "github"
@@ -72,17 +72,18 @@
         ]
       },
       "locked": {
-        "lastModified": 1766770015,
-        "narHash": "sha256-kUmVBU+uBUPl/v3biPiWrk680b8N9rRMhtY97wsxiJc=",
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "rev": "e4dba54ddb6b2ad9c6550e5baaed2fa27938a5d2",
-        "type": "github"
+        "lastModified": 1777031316,
+        "narHash": "sha256-qmxSz9icdvGy/X2zmrL7HkUShVd3fjg1MyOYbmi57vs=",
+        "ref": "refs/pull/397/head",
+        "rev": "7022c975470ea83fbc25a38e758d3376110d8695",
+        "revCount": 674,
+        "type": "git",
+        "url": "https://github.com/nix-community/nixos-images"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "type": "github"
+        "ref": "refs/pull/397/head",
+        "type": "git",
+        "url": "https://github.com/nix-community/nixos-images"
       }
     },
     "nixos-stable": {
@@ -103,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769900851,
-        "narHash": "sha256-RgCgXS3WiG9c/1wxFM6OXmmv39dSaLLON9VeAbTTAIM=",
+        "lastModified": 1776493722,
+        "narHash": "sha256-x7g61srKaynpFC0WCC0MwL5YMcy2w3/fBB1zMruUIrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30a3e96da641620c63f2e1f345ea434ac78f5de1",
+        "rev": "f616a759213aa26b647cdd517d48c0fb0dcd6bf0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -72,18 +72,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1777031316,
-        "narHash": "sha256-qmxSz9icdvGy/X2zmrL7HkUShVd3fjg1MyOYbmi57vs=",
-        "ref": "refs/pull/397/head",
-        "rev": "7022c975470ea83fbc25a38e758d3376110d8695",
-        "revCount": 674,
-        "type": "git",
-        "url": "https://github.com/nix-community/nixos-images"
+        "lastModified": 1778754897,
+        "narHash": "sha256-UlPBPrqOYTDB9g/8pUaIUzYpGgjQL/YMK3Ein6m9DkY=",
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "rev": "66fe34a02cc29c825fdb4ece1a79c17e8f2ade2e",
+        "type": "github"
       },
       "original": {
-        "ref": "refs/pull/397/head",
-        "type": "git",
-        "url": "https://github.com/nix-community/nixos-images"
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "type": "github"
       }
     },
     "nixos-stable": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     # used for testing
     disko = { url = "github:nix-community/disko/master"; inputs.nixpkgs.follows = "nixpkgs"; };
     nixos-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixos-images.url = "git+https://github.com/nix-community/nixos-images?ref=refs/pull/397/head";
+    nixos-images.url = "github:nix-community/nixos-images";
     nixos-images.inputs.nixos-unstable.follows = "nixpkgs";
     nixos-images.inputs.nixos-stable.follows = "nixos-stable";
     # https://github.com/numtide/nix-vm-test/pull/105

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,11 @@
     # used for testing
     disko = { url = "github:nix-community/disko/master"; inputs.nixpkgs.follows = "nixpkgs"; };
     nixos-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixos-images.url = "github:nix-community/nixos-images";
+    nixos-images.url = "git+https://github.com/nix-community/nixos-images?ref=refs/pull/397/head";
     nixos-images.inputs.nixos-unstable.follows = "nixpkgs";
     nixos-images.inputs.nixos-stable.follows = "nixos-stable";
     # https://github.com/numtide/nix-vm-test/pull/105
-    nix-vm-test = { url = "github:Enzime/nix-vm-test/pr-105-latest"; inputs.nixpkgs.follows = "nixpkgs"; };
+    nix-vm-test = { url = "github:a-kenji/nix-vm-test/pr-105-latest"; inputs.nixpkgs.follows = "nixpkgs"; };
 
     # used for development
     treefmt-nix = { url = "github:numtide/treefmt-nix"; inputs.nixpkgs.follows = "nixpkgs"; };

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -35,7 +35,7 @@
       });
       fedora-kexec-test = import ./linux-kexec-test.nix (linuxTestInputs // {
         distribution = "fedora";
-        version = "40";
+        version = "43";
       });
       debian-kexec-test = import ./linux-kexec-test.nix (linuxTestInputs // {
         distribution = "debian";

--- a/tests/from-nixos-build-on-remote.nix
+++ b/tests/from-nixos-build-on-remote.nix
@@ -24,7 +24,7 @@
               "virtio-blk-pci,drive=drive1",
           ]
           machine = create_machine(start_command=" ".join(start_command), **kwargs)
-          driver.machines.append(machine)
+          driver.machines_qemu.append(machine)
           return machine
       start_all()
 

--- a/tests/from-nixos.nix
+++ b/tests/from-nixos.nix
@@ -24,7 +24,7 @@
               "virtio-blk-pci,drive=drive1",
           ]
           machine = create_machine(start_command=" ".join(start_command), **kwargs)
-          driver.machines.append(machine)
+          driver.machines_qemu.append(machine)
           return machine
       start_all()
       installer.succeed("mkdir -p /tmp/extra-files/var/lib/secrets")

--- a/treefmt/flake-module.nix
+++ b/treefmt/flake-module.nix
@@ -11,6 +11,7 @@
       programs.terraform.enable = true;
       programs.deno.enable = !pkgs.deno.meta.broken;
       settings.formatter.shellcheck.options = [ "-s" "bash" ];
+      settings.formatter.shfmt.excludes = [ "src/nixos-anywhere.sh" ];
     };
     formatter = config.treefmt.build.wrapper;
   };


### PR DESCRIPTION
Update `nixpkgs` and prepare more updates.
Because of heavy development in nix-vm-test as well as networking and a
lot of changes in the nixos vm test driver this is a bit more involved
than I would like.

- rebases nix-vm-test PR:105
- disables network manager in nixos-images for phase 2: [#397.](https://github.com/nix-community/nixos-images/pull/397)
