### PR TITLE
nixos-anywhere: bump default kexec image to nixos-25.11

### DIFF
--- a/src/nixos-anywhere.sh
+++ b/src/nixos-anywhere.sh
@@ -709,7 +709,7 @@ runKexec() {
   if [[ $kexecUrl == "" ]]; then
     case "${isArch}" in
     x86_64 | aarch64)
-      kexecUrl="https://github.com/nix-community/nixos-images/releases/download/nixos-25.05/nixos-kexec-installer-noninteractive-${isArch}-linux.tar.gz"
+      kexecUrl="https://github.com/nix-community/nixos-images/releases/download/nixos-25.11/nixos-kexec-installer-noninteractive-${isArch}-linux.tar.gz"
       ;;
     *)
       abort "Unsupported architecture: ${isArch}. Our default kexec images only support x86_64 and aarch64 CPUs. Check out https://nix-community.github.io/nixos-anywhere/howtos/custom-kexec.html for more information."


### PR DESCRIPTION
nixos-images released the 25.11 branch. Bump the default kexec installer URL so new installs pick up the current channel by default.